### PR TITLE
Optimized levelup max algorithm, separate command

### DIFF
--- a/commands/Game/levelup.js
+++ b/commands/Game/levelup.js
@@ -48,7 +48,40 @@ module.exports = {
           return
         }
       }
-    } else {
+    } 
+    else if (args.length === 1 && args[0].toLowerCase() === 'experimentalmax') {
+      // we only want the multiplicative algorithm to kick in if more than 100000 levelups are affordable because the series needs to converge on a cubic ratio
+      if (player.currencies.coins.current > Calc.getCumulativeLevelUpCost(player.level, player.level + 100000)) {
+        let costOfCurrentLevel = Calc.getCumulativeLevelUpCost(0, player.level)
+        let moneyMultiple = player.currencies.coins.current / costOfCurrentLevel // how many times more money the player has than the cost of the current level
+        let levelMultiple = Math.pow(moneyMultiple + 1, 1 / 3) // how much the player's level will be multiplied by if they spend all their money leveling up
+        level = Math.floor(player.level * (levelMultiple - 1))
+        totalCost = Calc.getCumulativeLevelUpCost(player.level, player.level + level)
+      }
+      if (level === 0) {
+        message.reply('You broke... use !levelup max if you cannot afford at least 100k levels.')
+        return
+      }
+      if (level === NaN) {
+        message.reply('Aborting experimentalmax, level is NaN :(')
+        return
+      }
+      if (totalCost === NaN) {
+        message.reply('Aborting experimentalmax, totalCost is NaN :(')
+        return
+      }
+      player = await Player.findOneAndUpdate(
+        { id: player.id },
+        {
+          $inc: { level: level, 'currencies.coins.current': -totalCost },
+          lastCheck: new Date(),
+        },
+        { new: true }
+      )
+      message.reply('You leveled up: ' + level + ' times. It cost :coin: ' + totalCost + '. Your new level is ' + player.level)
+      return
+    }
+    else {
       let cost = await Calc.getLevelUpCost(level + player.level)
       if (cost > player.currencies.coins.current) {
         message.reply('You broke...')


### PR DESCRIPTION
Can compute max reachable level with current balance using the convergence of the function f(x) = ( sum of (n^2) from n=1 to n=x ) where f(b*x)/f(x) ≈ b^3 for large x. In simple terms, if you have spent a total of x coins to reach a level y, then it takes a total of 8x coins to reach a level 2y. This means that you need a balance of 7x coins (you already spent x many coins, 8x is the total) to level up y times (from y to 2y). (granted that x and y are sufficiently large.) However, a perfect convergence takes an obscenely high level, so this algorithm might give a few too many / a few too little levels, which might set the balance negative, so I made it a separate command so players know what they're doing. If it works as intended then it can be rolled into the main command. Players will always be charged the appropriate amount for their levelups (see the formula in Calc.js, plug in any values you want) so it is not exploitable. There are also NaN checks to prevent data corruption.

## Describe your changes


## Issue ticket number and link
Closes #<issue number>

## Checklist before requesting a review
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas as neccessary
- [ ] My changes generate no new warnings
- [ ] I have self-reviewed my own code
- [ ] I have created thorough tests and maximized code coverage
- [ ] Do we need to implement analytics?
- [ ] New and existing unit tests pass locally with my changes

## Screenshots (if appropriate)
